### PR TITLE
define required resource attribute for graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ profiles = c.profiles.list(order='name', direction='asc', limit=10, offset=30, s
 c.profiles.delete(profile['uuid'])
 
 # Running GraphQL query
-c.graphql.query('{ hello }')
+c.graphql.query({'query': '{ hello }'})
 ```
 
 

--- a/wazo_dird_client/commands/graphql.py
+++ b/wazo_dird_client/commands/graphql.py
@@ -5,9 +5,11 @@ from .helpers.base_command import DirdRESTCommand
 
 
 class GraphQLCommand(DirdRESTCommand):
+
+    resource = 'graphql'
+
     def query(self, query, tenant_uuid, token):
         headers = self.build_rw_headers(tenant_uuid, token)
-        url = self._client.url('graphql')
-        r = self.session.post(url, json=query, headers=headers)
+        r = self.session.post(self.base_url, json=query, headers=headers)
         self.raise_from_response(r)
         return r.json()


### PR DESCRIPTION
reason: otherwise it is an abstract property
* fix README