### PR TITLE
Dird-Client: Implement `config` command and exception for new restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ c = Client(...)
 c.foo.bar()  # bar is a method of the FooCommand class
 ```
 
+
+How to access `config` endpoint on `wazo-dird` using `config` command
+---------------------------------------------------------------------
+
+One can access the configuration of `wazo-dird` (`config` plugin) by using the following:
+
+```python
+
+from wazo_dird_client import Client as DirdClient
+
+dird_client = DirdClient('127.0.0.1', port=9489, token='valid-master-token')
+config = dird_client.config.get(tenant_uuid='valid-master-tenant-uuid')
+
+```
+
+##Note:
+
+Notice that the `config` endpoint is restricted to be accessible only by the `master` tenant; otherwise, an HTTP 401 error (`DirdError`) will be thrown.
+
+
 Running unit tests
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'wazo_dird_client.commands': [
             'backends = wazo_dird_client.commands.backends:BackendsCommand',
             'conference_source = wazo_dird_client.commands.conference_source:Command',
+            'config = wazo_dird_client.commands.config:ConfigCommand',
             'csv_source = wazo_dird_client.commands.csv_source:Command',
             'csv_ws_source = wazo_dird_client.commands.csv_ws_source:Command',
             'directories = wazo_dird_client.commands.directories:DirectoriesCommand',

--- a/wazo_dird_client/command.py
+++ b/wazo_dird_client/command.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_lib_rest_client.command import RESTCommand

--- a/wazo_dird_client/command.py
+++ b/wazo_dird_client/command.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from wazo_lib_rest_client.command import RESTCommand
+
+from .exceptions import DirdError
+from .exceptions import DirdServiceUnavailable
+from .exceptions import InvalidDirdError
+
+
+class DirdCommand(RESTCommand):
+    @staticmethod
+    def raise_from_response(response):
+        if response.status_code == 503:
+            raise DirdServiceUnavailable(response)
+
+        try:
+            raise DirdError(response)
+        except InvalidDirdError:
+            RESTCommand.raise_from_response(response)

--- a/wazo_dird_client/commands/config.py
+++ b/wazo_dird_client/commands/config.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from wazo_dird_client.command import DirdCommand
+
+
+class ConfigCommand(DirdCommand):
+
+    resource = 'config'
+
+    def get(self):
+        headers = self._get_headers()
+        r = self.session.get(self.base_url, headers=headers)
+        self.raise_from_response(r)
+        return r.json()
+
+    def patch(self, config_patch):
+        headers = self._get_headers()
+        r = self.session.patch(self.base_url, headers=headers, json=config_patch)
+        self.raise_from_response(r)
+        return r.json()

--- a/wazo_dird_client/commands/config.py
+++ b/wazo_dird_client/commands/config.py
@@ -9,8 +9,8 @@ class ConfigCommand(DirdCommand):
 
     resource = 'config'
 
-    def get(self):
-        headers = self._get_headers()
+    def get(self, tenant_uuid=None):
+        headers = self._get_headers(tenant_uuid=tenant_uuid)
         r = self.session.get(self.base_url, headers=headers)
         self.raise_from_response(r)
         return r.json()

--- a/wazo_dird_client/commands/config.py
+++ b/wazo_dird_client/commands/config.py
@@ -14,9 +14,3 @@ class ConfigCommand(DirdCommand):
         r = self.session.get(self.base_url, headers=headers)
         self.raise_from_response(r)
         return r.json()
-
-    def patch(self, config_patch):
-        headers = self._get_headers()
-        r = self.session.patch(self.base_url, headers=headers, json=config_patch)
-        self.raise_from_response(r)
-        return r.json()

--- a/wazo_dird_client/commands/config.py
+++ b/wazo_dird_client/commands/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_dird_client.command import DirdCommand

--- a/wazo_dird_client/commands/status.py
+++ b/wazo_dird_client/commands/status.py
@@ -8,8 +8,8 @@ class StatusCommand(DirdRESTCommand):
 
     resource = 'status'
 
-    def get(self):
-        headers = self.build_headers()
+    def get(self, tenant_uuid=None):
+        headers = self.build_headers(tenant_uuid=tenant_uuid)
         r = self.session.get(self.base_url, headers=headers)
         self.raise_from_response(r)
         return r.json()

--- a/wazo_dird_client/exceptions.py
+++ b/wazo_dird_client/exceptions.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
 
 from requests import HTTPError
 

--- a/wazo_dird_client/exceptions.py
+++ b/wazo_dird_client/exceptions.py
@@ -32,3 +32,7 @@ class DirdError(HTTPError):
 
 class InvalidDirdError(Exception):
     pass
+
+
+class DirdServiceUnavailable(DirdError):
+    pass

--- a/wazo_dird_client/exceptions.py
+++ b/wazo_dird_client/exceptions.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from requests import HTTPError
+
+
+class DirdError(HTTPError):
+    def __init__(self, response):
+        try:
+            body = response.json()
+        except ValueError:
+            raise InvalidDirdError()
+
+        if not body:
+            raise InvalidDirdError()
+
+        self.status_code = response.status_code
+        try:
+            self.message = body['message']
+            self.error_id = body['error_id']
+            self.details = body['details']
+            self.timestamp = body['timestamp']
+
+        except KeyError:
+            raise InvalidDirdError()
+
+        exception_message = '{e.message}: {e.details}'.format(e=self)
+        super(DirdError, self).__init__(exception_message, response=response)
+
+
+class InvalidDirdError(Exception):
+    pass


### PR DESCRIPTION
* Add an exception to catch when `config` endpoint is being accessed by other tenants rather than the `master_tenant`,
* Add `config` and `DirdCommand` commands to `dird-client`,
* Add `tenant_uuid` to `get` method's header in: `config` and `status` commands.